### PR TITLE
BaseActivity Appcompat 적용

### DIFF
--- a/app/src/main/kotlin/team/ommaya/wequiz/android/base/BaseViewBindingActivity.kt
+++ b/app/src/main/kotlin/team/ommaya/wequiz/android/base/BaseViewBindingActivity.kt
@@ -7,14 +7,14 @@
 
 package team.ommaya.wequiz.android.base
 
-import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
+import androidx.appcompat.app.AppCompatActivity
 import androidx.viewbinding.ViewBinding
 
 abstract class BaseViewBindingActivity<VB : ViewBinding>(
     private val bindingInflater: (inflater: LayoutInflater) -> VB,
-) : Activity() {
+) : AppCompatActivity() {
 
     private var _binding: VB? = null
 


### PR DESCRIPTION
- activity에서 viewModels() delegate를 사용하기 위해 Appcompat적용
- NavHost, NavController 설정을 위해 변경
